### PR TITLE
Specify full paramater definition in decl. C89's 'implicit int' is an error here.

### DIFF
--- a/src/flash/nor/wcharm.c
+++ b/src/flash/nor/wcharm.c
@@ -141,8 +141,8 @@ static int ch32x_get_device_id(struct flash_bank *bank, uint32_t *device_id);
 static int ch32x_write_block(struct flash_bank *bank, const uint8_t *buffer,
 		uint32_t address, uint32_t count);
 extern int wlink_armcheckprotect(void);
-extern void wlink_sendchip(config);
-	
+extern void wlink_sendchip(uint8_t config);
+
 
 
 /* flash bank ch32x <base> <size> 0 0 <target#>


### PR DESCRIPTION
With -Werror removed, this is the only fatal error when building on MacOS.

Change-Id: If5590a17097d63d6c2155c626b5c58673953c477
Signed-off-by: Robert Lipe <robertlipe@gmail.com>
