### PR TITLE
add WCH-LinkE r0 1v3 support, maybe future version also get supported

### DIFF
--- a/src/jtag/drivers/cmsis_dap_usb_bulk.c
+++ b/src/jtag/drivers/cmsis_dap_usb_bulk.c
@@ -658,11 +658,11 @@ void wlink_armversion(struct cmsis_dap *dap){
 			wlink_name="WCH-LinkE-CH32V307 r0-1v3  mod:ARM";
 			break;
 		default:
-			// do not report error when we did not know the version,
-			// hope it can support more WCH-LinkE devices in future.
-			LOG_WARNING("unknown reply: %d, WCH-Link unknown version: %d.%d ", rxbuf[5], rxbuf[3], rxbuf[4]);
-			LOG_WARNING("If it not works properly, please report a issue to: https://github.com/cjacker/wch-openocd.");
-			wlink_name="WCH-Link Unknown version mod:ARM";
+                        // do not report error with unknown version,
+                        // hope it could work with more WCH-LinkE devices in future.
+                        LOG_WARNING("Unknown version: %d.%d with reply value: %d", rxbuf[3], rxbuf[4], rxbuf[5]);
+                        LOG_WARNING("If it not works, report a issue with above line to: https://github.com/karlp/openocd-hacks");
+                        wlink_name="Unknown  mod:ARM";
 			break;
 		}
 	LOG_INFO("%s version %d.%d ",wlink_name, rxbuf[3], rxbuf[4]);

--- a/src/jtag/drivers/cmsis_dap_usb_bulk.c
+++ b/src/jtag/drivers/cmsis_dap_usb_bulk.c
@@ -646,7 +646,7 @@ void wlink_armversion(struct cmsis_dap *dap){
 			wlink549=true;
 			break;
 		case 2:
-			wlink_name="WCH-LinkE-CH32V307  mod:ARM";
+			wlink_name="WCH-LinkE-CH32V307 r0-1v2  mod:ARM";
 			break;
 		case 3:
 			wlink_name="WCH-LinkS-CH32V203  mod:ARM";
@@ -654,8 +654,15 @@ void wlink_armversion(struct cmsis_dap *dap){
 		case 4:
 			wlink_name="WCH-LinkB  mod:ARM";
 			break;
+		case 18:
+			wlink_name="WCH-LinkE-CH32V307 r0-1v3  mod:ARM";
+			break;
 		default:
-			LOG_ERROR("unknow WCH-LINK ");	
+			// do not report error when we did not know the version,
+			// hope it can support more WCH-LinkE devices in future.
+			LOG_WARNING("unknown reply: %d, WCH-Link unknown version: %d.%d ", rxbuf[5], rxbuf[3], rxbuf[4]);
+			LOG_WARNING("If it not works properly, please report a issue to: https://github.com/cjacker/wch-openocd.");
+			wlink_name="WCH-Link Unknown version mod:ARM";
 			break;
 		}
 	LOG_INFO("%s version %d.%d ",wlink_name, rxbuf[3], rxbuf[4]);

--- a/src/jtag/drivers/wlink.c
+++ b/src/jtag/drivers/wlink.c
@@ -1476,7 +1476,7 @@ int wlink_init(void)
 			wlink549=true;
 			break;
 		case 2:
-			wlink_name="WCH-LinkE-CH32V307  mod:RV";
+			wlink_name="WCH-LinkE-CH32V307 r0-1v2 mod:RV";
 			break;
 		case 3:
 			wlink_name="WCH-LinkS-CH32V203  mod:RV";
@@ -1484,9 +1484,15 @@ int wlink_init(void)
 		case 4:
 			wlink_name="WCH-LinkB  mod:RV";
 			break;
+		case 18:
+			wlink_name="WCH-LinkE-CH32V307 r0-1v3  mod:RV";
+			break;
 		default:
-			LOG_ERROR("unknow WCH-LINK ");	
-			goto error_wlink;
+			// do not report error when we did not know the version,
+			// hope it can support more WCH-LinkE devices in future.
+			LOG_WARNING("unknown reply: %d, WCH-LINK unknown version: %d.%d ", rxbuf[5], rxbuf[3], rxbuf[4]);
+			LOG_WARNING("If it not works properly, please report a issue to: https://github.com/cjacker/wch-openocd.");
+			wlink_name="WCH-Link Unknown version mod:RV";
 			break;
 		}
 		LOG_INFO("%s version %d.%d ",wlink_name, rxbuf[3], rxbuf[4]);

--- a/src/jtag/drivers/wlink.c
+++ b/src/jtag/drivers/wlink.c
@@ -1488,11 +1488,11 @@ int wlink_init(void)
 			wlink_name="WCH-LinkE-CH32V307 r0-1v3  mod:RV";
 			break;
 		default:
-			// do not report error when we did not know the version,
-			// hope it can support more WCH-LinkE devices in future.
-			LOG_WARNING("unknown reply: %d, WCH-LINK unknown version: %d.%d ", rxbuf[5], rxbuf[3], rxbuf[4]);
-			LOG_WARNING("If it not works properly, please report a issue to: https://github.com/cjacker/wch-openocd.");
-			wlink_name="WCH-Link Unknown version mod:RV";
+			// do not report error with unknown version,
+			// hope it could work with more WCH-LinkE devices in future.
+			LOG_WARNING("Unknown version: %d.%d with reply value: %d", rxbuf[3], rxbuf[4], rxbuf[5]);
+			LOG_WARNING("If it not works, report a issue with above line to: https://github.com/karlp/openocd-hacks");
+			wlink_name="Unknown  mod:RV";
 			break;
 		}
 		LOG_INFO("%s version %d.%d ",wlink_name, rxbuf[3], rxbuf[4]);


### PR DESCRIPTION
Hi,

As user report, WCH-LinkE r0 1v3 does not work with this openocd fork.

I got a r0 1v3 adapter recently and make some changes to make it work, tested with r0 1v2 with firmware version v2.8 and r0 1v3 with firmware version v2.14.

With these changes, maybe future version can also work without change the codes. 